### PR TITLE
chore: don't default to releases page

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,6 @@ struct Config {
 impl Config {
     fn new() -> Config {
         Config {
-            // TODO: the latest should be the default here.
-            template: String::from("https://github.com/{project}/releases"),
             ..Default::default()
         }
     }


### PR DESCRIPTION
It's confusing. lifter is not specific to github, so
it's wrong to use a github URL as a default.