### PR TITLE
Add commit-tracking feature for repos like neovim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,7 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: >
+          index.crates.io:443
           crates.io:443
           github.com:443
           static.crates.io:443

--- a/lifter.config
+++ b/lifter.config
@@ -342,8 +342,10 @@ version = 2021-07-05
 [nvim]
 template = github_api_latest
 project = neovim/neovim
+commit_tag = $.target_commitish
 anchor_text = nvim.appimage
-version = v0.5.0
+version = stable
+commit = 7d4bba7aa7a4a3444919ea7a3804094c290395ef
 
 [ncspot]
 template = github_api_latest


### PR DESCRIPTION
Neovim always uses the same tag "stable", and when a release happens the tag is moved to a new commit. So this new feature enables "commit tracking" in addition to version tracking.